### PR TITLE
Fix the get method to make it return all rooms when the id argument is falsy

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -49,7 +49,8 @@ Adapter.prototype.add = function add(id, room, cb) {
 };
 
 /**
- * Get rooms socket is subscribed to.
+ * Get the list of rooms joined by the socket or the list
+ * of all active rooms.
  *
  * @param {String} id Socket id
  * @param {Function} cb callback
@@ -58,7 +59,16 @@ Adapter.prototype.add = function add(id, room, cb) {
 
 Adapter.prototype.get = function get(id, cb) {
   cb = cb || noop;
-  this.client.smembers(socketKey.format(id), cb);
+
+  if (id) return this.client.smembers(socketKey.format(id), cb);
+
+  this.client.keys('room:*', function (err, rooms) {
+    if (err) return cb(err);
+
+    cb(undefined, rooms.map(function (room) {
+      return room.slice(5);
+    }));
+  });
 };
 
 /**

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -70,6 +70,14 @@ describe('Adapter', function () {
         done();
       });
     });
+
+    it('should return all rooms when the `id` argument is falsy', function (done) {
+      adapter.get(null, function (err, rooms) {
+        if (err) return done(err);
+        expect(rooms).to.have.members(['my:room:name', 'my:second:room:name']);
+        done();
+      });
+    });
   });
 
   describe('#del', function () {


### PR DESCRIPTION
This fixes an issue that was preventing the [`primus.rooms([spark], [fn])`](https://github.com/cayasso/primus-rooms#primusroomsspark-fn) API from working correctly.
When the `spark` or the `id` is not passed the method should return all the active rooms.
