### PR TITLE
Make Redis connection parameters fall back to their default values.

### DIFF
--- a/lib/primus-cluster.js
+++ b/lib/primus-cluster.js
@@ -48,7 +48,10 @@ function PrimusCluster(primus, options) {
  */
 
 PrimusCluster.prototype.initializeClients = function initializeClients(options) {
-  options = options || {};
+  options = _.defaults(options || {}, {
+    host: '127.0.0.1',
+    port: 6379
+  });
 
   this.clients = {};
 


### PR DESCRIPTION
The `createClient` method has been slightly changed in `node_redis@0.12.x`.
It no longer works when used like this: `redis.createClient(undefined, undefined, options);`

This ensures that default values are used when the connection parameters (`port` and/or `host`) are not specified.
